### PR TITLE
qed approx methods now accounts for photon losses in the cavity via imaginary frequency

### DIFF
--- a/adcc/ReferenceState.py
+++ b/adcc/ReferenceState.py
@@ -142,7 +142,8 @@ class ReferenceState(libadcc.ReferenceState):
         """
         self.qed = qed
         self.coupling = coupl
-        self.frequency = freq
+        self.frequency = np.real(freq)
+        self.freq_with_loss = freq
         self.qed_hf = qed_hf
         self.approx = qed_approx
         self.full_diagonalization = qed_full_diag

--- a/adcc/qed_matrix_from_diag_adc.py
+++ b/adcc/qed_matrix_from_diag_adc.py
@@ -31,6 +31,7 @@ class qed_matrix_from_diag_adc:
         self.h1 = exstates.qed_second_order_ph_ph_couplings
         self.coupl = refstate.coupling[2]
         self.freq = refstate.frequency[2]
+        self.full_freq = refstate.freq_with_loss[2]
         self.n_adc = len(exstates.excitation_energy)
         self.exc_en = exstates.excitation_energy
 
@@ -46,6 +47,9 @@ class qed_matrix_from_diag_adc:
         s2s_block = - np.sqrt(self.freq / 2) * self.coupl *\
             np.sqrt(2 * self.freq) * self.s2s["qed_adc1_off_diag"]
         tdm_block = - np.sqrt(self.freq / 2) * tdm_block
+
+        if np.iscomplex(self.full_freq):
+            self.freq = self.full_freq
 
         elec_block = np.diag(self.exc_en)
         phot_block = np.diag(self.exc_en + self.freq)
@@ -63,7 +67,10 @@ class qed_matrix_from_diag_adc:
                             matrix_middle.reshape((len(matrix_middle), 1)),
                             matrix_lower))
 
-        return sp.eigh(matrix)
+        if np.iscomplex(self.full_freq):
+            return sp.eig(matrix)
+        else:
+            return sp.eigh(matrix)
 
     def second_order_coupling(self):
 
@@ -111,6 +118,9 @@ class qed_matrix_from_diag_adc:
 
         # build the blocks of the matrix
 
+        if np.iscomplex(self.full_freq):
+            self.freq = self.full_freq
+
         single_excitation_states = np.ones(self.n_adc)
 
         elec_block = np.diag(self.exc_en) + qed_adc2_diag_block
@@ -150,4 +160,7 @@ class qed_matrix_from_diag_adc:
                             matrix_3, matrix_4.reshape((len(matrix_4), 1)),
                             matrix_5))
 
-        return sp.eigh(matrix)
+        if np.iscomplex(self.full_freq):
+            return sp.eig(matrix)
+        else:
+            return sp.eigh(matrix)

--- a/adcc/test_qed.py
+++ b/adcc/test_qed.py
@@ -53,6 +53,7 @@ class qed_test(unittest.TestCase):
         self.refstate = adcc.ReferenceState(cache.hfdata[case])
         self.refstate.coupling = [0.0, 0.0, 0.05]
         self.refstate.frequency = [0.0, 0.0, 0.5]
+        self.refstate.freq_with_loss = self.refstate.frequency
         self.refstate.qed_hf = True
         self.refstate.qed = True
 

--- a/adcc/workflow.py
+++ b/adcc/workflow.py
@@ -408,11 +408,24 @@ def validate_state_parameters(reference_state, n_states=None, n_singlets=None,
         if not (coupl is not None and freq is not None):
             raise InputError("qed calculation requires coupl and freq")
         if len(coupl) != 3 or len(freq) != 3:
-            raise InputError("freq and coupl must contain 3 elements,"
+            raise InputError("freq and coupl must contain 3 elements, "
                              "i.e. x, y, z")
+        if any(np.iscomplex(freq)) and not qed_approx:
+            raise InputError("imaginary contribution to freq will only be "
+                             "processed, if qed_approx=True")
+        if freq[0] != 0 or freq[1] != 0:
+            if qed_approx:
+                raise InputError("only request qed_approx=True with the cavity "
+                                 "photon polarized in z direction")
+            else:
+                raise Warning("polarizations of the cavity photon different from "
+                              "z polarization have not been thoroughly tested yet")
     if not qed_hf:
-        raise InputError("QED-ADC of zeroth and first level are not yet"
+        raise InputError("QED-ADC of zeroth and first level are not yet "
                          "properly tested and second order is not implemented")
+    if qed_full_diag:
+        raise Warning("Care to only request qed_full_diag=True, if you ask for "
+                      "the maximum number of states possible")
 
     return n_states, kind
 


### PR DESCRIPTION
qed approx method is now able to account for photon losses in the cavity, due to an imaginary contribution on the diagonal of the final qed-matrix, which is requested as imaginary part of the cavity photon energy