### PR TITLE
Review cycle1

### DIFF
--- a/adcc/AdcMatrix.py
+++ b/adcc/AdcMatrix.py
@@ -132,6 +132,9 @@ class AdcMatrix(AdcMatrixlike):
             if method.base_method.name in ["adc2x", "adc3"] or self.is_core_valence_separated:  # noqa: E501
                 raise NotImplementedError("Neither adc2x and adc3 nor cvs methods "
                                           "are implemented for QED-ADC")
+            elif method.base_method.name == "adc2" and not self.reference_state.qed_hf:  # noqa: E501
+                raise NotImplementedError("QED-ADC(2) is only available for a "
+                                          "QED-HF reference")
 
         self.intermediates = intermediates
         if self.intermediates is None:

--- a/adcc/AmplitudeVector.py
+++ b/adcc/AmplitudeVector.py
@@ -143,12 +143,20 @@ class AmplitudeVector(dict):
         or the dot products with a list of AmplitudeVectors.
         In the latter case a np.ndarray is returned.
         """
+        # __forward_to_blocks cannot handle int and float
+        #gs_keys = ("gs1", "gs2")
         if isinstance(other, list):
             # Make a list where the first index is all singles parts,
             # the second is all doubles parts and so on
             return sum(self[b].dot([av[b] for av in other]) for b in self.keys())
+            #           if b not in gs_keys)
+            #        + sum(self[b] * [av[b] for av in other]
+            #           for b in self.keys() if b in gs_keys))
         else:
             return sum(self[b].dot(other[b]) for b in self.keys())
+            #           if b not in gs_keys)
+            #        + sum(self[b] * other[b] for b in self.keys()
+            #           if b in gs_keys))
 
     def __matmul__(self, other):
         if isinstance(other, AmplitudeVector):
@@ -157,6 +165,16 @@ class AmplitudeVector(dict):
             if all(isinstance(elem, AmplitudeVector) for elem in other):
                 return self.dot(other)
         return NotImplemented
+
+    #def __forward_to_blocks_scalar(self, fname, other, scalar_keys):
+    #    if isinstance(other, AmplitudeVector):
+    #        if sorted(other.blocks_ph) != sorted(self.blocks_ph):
+    #            raise ValueError("Blocks of both AmplitudeVector objects "
+    #                             f"need to agree to perform {fname}")
+    #        ret = {k: getattr(tensor, fname)(other[k])
+    #               for k, tensor in self.items()}
+    #    else:
+    #        ret = {k: getattr(tensor, fname)(other) for k, tensor in self.items()}
 
     def __forward_to_blocks(self, fname, other):
         if isinstance(other, AmplitudeVector):
@@ -168,6 +186,8 @@ class AmplitudeVector(dict):
         else:
             ret = {k: getattr(tensor, fname)(other) for k, tensor in self.items()}
         if any(r == NotImplemented for r in ret.values()):
+            #if "gs1" in self.blocks_ph:
+            #    scalar_keys = [k for k in ret.keys() if ret[k] == NotImplemented]   
             return NotImplemented
         else:
             return AmplitudeVector(**ret)

--- a/adcc/AmplitudeVector.py
+++ b/adcc/AmplitudeVector.py
@@ -22,8 +22,6 @@
 ## ---------------------------------------------------------------------
 import warnings
 
-import numpy as np
-
 
 class AmplitudeVector(dict):
     def __init__(self, *args, **kwargs):
@@ -143,20 +141,12 @@ class AmplitudeVector(dict):
         or the dot products with a list of AmplitudeVectors.
         In the latter case a np.ndarray is returned.
         """
-        # __forward_to_blocks cannot handle int and float
-        #gs_keys = ("gs1", "gs2")
         if isinstance(other, list):
             # Make a list where the first index is all singles parts,
             # the second is all doubles parts and so on
             return sum(self[b].dot([av[b] for av in other]) for b in self.keys())
-            #           if b not in gs_keys)
-            #        + sum(self[b] * [av[b] for av in other]
-            #           for b in self.keys() if b in gs_keys))
         else:
             return sum(self[b].dot(other[b]) for b in self.keys())
-            #           if b not in gs_keys)
-            #        + sum(self[b] * other[b] for b in self.keys()
-            #           if b in gs_keys))
 
     def __matmul__(self, other):
         if isinstance(other, AmplitudeVector):
@@ -165,16 +155,6 @@ class AmplitudeVector(dict):
             if all(isinstance(elem, AmplitudeVector) for elem in other):
                 return self.dot(other)
         return NotImplemented
-
-    #def __forward_to_blocks_scalar(self, fname, other, scalar_keys):
-    #    if isinstance(other, AmplitudeVector):
-    #        if sorted(other.blocks_ph) != sorted(self.blocks_ph):
-    #            raise ValueError("Blocks of both AmplitudeVector objects "
-    #                             f"need to agree to perform {fname}")
-    #        ret = {k: getattr(tensor, fname)(other[k])
-    #               for k, tensor in self.items()}
-    #    else:
-    #        ret = {k: getattr(tensor, fname)(other) for k, tensor in self.items()}
 
     def __forward_to_blocks(self, fname, other):
         if isinstance(other, AmplitudeVector):
@@ -186,8 +166,6 @@ class AmplitudeVector(dict):
         else:
             ret = {k: getattr(tensor, fname)(other) for k, tensor in self.items()}
         if any(r == NotImplemented for r in ret.values()):
-            #if "gs1" in self.blocks_ph:
-            #    scalar_keys = [k for k in ret.keys() if ret[k] == NotImplemented]   
             return NotImplemented
         else:
             return AmplitudeVector(**ret)
@@ -239,160 +217,3 @@ class AmplitudeVector(dict):
         else:
             ret = {k: other + tensor for k, tensor in self.items()}
             return AmplitudeVector(**ret)
-
-
-class QED_AmplitudeVector:
-
-    # TODO: Initialize this class with **kwargs, and think of a functionality,
-    # which then eases up e.g. the matvec function in the AdcMatrix.py for
-    # arbitrarily large QED vectors. However, this is not necessarily required,
-    # since e.g. QED-ADC(3) is very complicated to derive and QED-ADC(1) (with
-    # just the single dispersion mode) is purely for academic purposes and
-    # hence not required to provide optimum performance.
-
-    def __init__(self, ph=None, pphh=None, gs1=None, ph1=None, pphh1=None,
-                 gs2=None, ph2=None, pphh2=None):
-
-        if pphh is not None:
-            self.elec = AmplitudeVector(ph=ph, pphh=pphh)
-            self.phot = AmplitudeVector(ph=ph1, pphh=pphh1)
-            self.phot2 = AmplitudeVector(ph=ph2, pphh=pphh2)
-        else:
-            self.elec = AmplitudeVector(ph=ph)
-            self.phot = AmplitudeVector(ph=ph1)
-            self.phot2 = AmplitudeVector(ph=ph2)
-
-        self.gs1 = gs1
-        self.gs2 = gs2
-        self.ph = ph
-        self.ph1 = ph1
-        self.ph2 = ph2
-        self.pphh = pphh
-        self.pphh1 = pphh1
-        self.pphh2 = pphh2
-
-    def dot(self, invec):
-        def dot_(self, invec):
-            if "pphh" in self.elec.blocks_ph:
-                return (self.elec.ph.dot(invec.elec.ph)
-                        + self.elec.pphh.dot(invec.elec.pphh)
-                        + self.gs1 * invec.gs1 + self.phot.ph.dot(invec.phot.ph)
-                        + self.phot.pphh.dot(invec.phot.pphh)
-                        + self.gs2 * invec.gs2 + self.phot2.ph.dot(invec.phot2.ph)
-                        + self.phot2.pphh.dot(invec.phot2.pphh))
-            else:
-                return (self.elec.ph.dot(invec.elec.ph)
-                        + self.gs1 * invec.gs1 + self.phot.ph.dot(invec.phot.ph)
-                        + self.gs2 * invec.gs2 + self.phot2.ph.dot(invec.phot2.ph))
-        if isinstance(invec, list):
-            return np.array([dot_(self, elem) for elem in invec])
-        else:
-            return dot_(self, invec)
-
-    def __matmul__(self, other):
-        if isinstance(other, QED_AmplitudeVector):
-            return self.dot(other)
-        if isinstance(other, list):
-            if all(isinstance(elem, QED_AmplitudeVector) for elem in other):
-                return self.dot(other)
-        return NotImplemented
-
-    def __sub__(self, invec):
-        if isinstance(invec, (float, int)):
-            if "pphh" in self.elec.blocks_ph:
-                return QED_AmplitudeVector(
-                    ph=self.elec.ph.__sub__(invec),
-                    pphh=self.elec.pphh.__sub__(invec),
-                    gs1=self.gs1 - invec, ph1=self.phot.ph.__sub__(invec),
-                    pphh1=self.phot.pphh.__sub__(invec),
-                    gs2=self.gs2 - invec, ph2=self.phot2.ph.__sub__(invec),
-                    pphh2=self.phot2.pphh.__sub__(invec))
-            else:
-                return QED_AmplitudeVector(
-                    ph=self.elec.ph.__sub__(invec),
-                    gs1=self.gs1 - invec, ph1=self.phot.ph.__sub__(invec),
-                    gs2=self.gs2 - invec, ph2=self.phot2.ph.__sub__(invec))
-
-    def __truediv__(self, other):
-        if isinstance(other, QED_AmplitudeVector):
-            if "pphh" in self.elec.blocks_ph:
-                return QED_AmplitudeVector(
-                    ph=self.elec.ph.__truediv__(other.elec.ph),
-                    pphh=self.elec.pphh.__truediv__(other.elec.pphh),
-                    gs1=self.gs1 / other.gs1,
-                    ph1=self.phot.ph.__truediv__(other.phot.ph),
-                    pphh1=self.phot.pphh.__truediv__(other.phot.pphh),
-                    gs2=self.gs2 / other.gs2,
-                    ph2=self.phot2.ph.__truediv__(other.phot2.ph),
-                    pphh2=self.phot2.pphh.__truediv__(other.phot2.pphh))
-            else:
-                return QED_AmplitudeVector(
-                    ph=self.elec.ph.__truediv__(other.elec.ph),
-                    gs1=self.gs1 / other.gs1,
-                    ph1=self.phot.ph.__truediv__(other.phot.ph),
-                    gs2=self.gs2 / other.gs2,
-                    ph2=self.phot2.ph.__truediv__(other.phot2.ph))
-        elif isinstance(other, (float, int)):
-            if "pphh" in self.elec.blocks_ph:
-                return QED_AmplitudeVector(
-                    ph=self.elec.ph.__truediv__(other),
-                    pphh=self.elec.pphh.__truediv__(other),
-                    gs1=self.gs1 / other, ph1=self.phot.ph.__truediv__(other),
-                    pphh1=self.phot.pphh.__truediv__(other),
-                    gs2=self.gs2 / other, ph2=self.phot2.ph.__truediv__(other),
-                    pphh2=self.phot2.pphh.__truediv__(other))
-            else:
-                return QED_AmplitudeVector(
-                    ph=self.elec.ph.__truediv__(other),
-                    gs1=self.gs1 / other, ph1=self.phot.ph.__truediv__(other),
-                    gs2=self.gs2 / other, ph2=self.phot2.ph.__truediv__(other))
-
-    def zeros_like(self):
-        if "pphh" in self.elec.blocks_ph:
-            return QED_AmplitudeVector(
-                ph=self.elec.zeros_like().ph,
-                pphh=self.elec.zeros_like().pphh,
-                gs1=0, ph1=self.phot.zeros_like().ph,
-                pphh1=self.phot.zeros_like().pphh,
-                gs2=0, ph2=self.phot2.zeros_like().ph,
-                pphh2=self.phot2.zeros_like().pphh)
-        else:
-            return QED_AmplitudeVector(
-                ph=self.elec.zeros_like().ph, pphh=None,
-                gs1=0, ph1=self.phot.zeros_like().ph, pphh1=None,
-                gs2=0, ph2=self.phot2.zeros_like().ph, pphh2=None)
-
-    def empty_like(self):
-        if "pphh" in self.elec.blocks_ph:
-            return QED_AmplitudeVector(
-                ph=self.elec.empty_like().ph,
-                pphh=self.elec.empty_like().pphh,
-                gs1=0, ph1=self.phot.empty_like().ph,
-                pphh1=self.phot.empty_like().pphh,
-                gs2=0, ph2=self.phot2.empty_like().ph,
-                pphh2=self.phot2.empty_like().pphh)
-        else:
-            QED_AmplitudeVector(
-                ph=self.elec.empty_like().ph, pphh=None,
-                gs1=0, ph1=self.phot.empty_like().ph, pphh1=None,
-                gs2=0, ph2=self.phot2.empty_like().ph, pphh2=None)
-
-    def copy(self):
-        if "pphh" in self.elec.blocks_ph:
-            return QED_AmplitudeVector(
-                ph=self.elec.copy().ph, pphh=self.elec.copy().pphh,
-                gs1=self.gs1, ph1=self.phot.copy().ph,
-                pphh1=self.phot.copy().pphh,
-                gs2=self.gs2, ph2=self.phot2.copy().ph,
-                pphh2=self.phot2.copy().pphh)
-        else:
-            QED_AmplitudeVector(
-                ph=self.elec.copy().ph, pphh=None,
-                gs1=self.gs1, ph1=self.phot.copy().ph, pphh1=None,
-                gs2=self.gs2, ph2=self.phot2.copy().ph, pphh2=None)
-
-    def evaluate(self):
-        self.elec.evaluate()
-        self.phot.evaluate()
-        self.phot2.evaluate()
-        return self

--- a/adcc/ElectronicTransition.py
+++ b/adcc/ElectronicTransition.py
@@ -187,20 +187,12 @@ class ElectronicTransition:
                 return transition_dm(self.method, self.ground_state,
                                      self.excitation_vector[i])
 
-            if hasattr(self.reference_state, "first_order_coupling"):
-
-                return np.array([
-                    [product_trace(comp, tdm(i, "adc0"))
-                     for comp in dipole_integrals]
-                    for i in np.arange(len(self.excitation_energy))
-                ])
-            else:
-                prop_level = "adc" + str(self.property_method.level - 1)
-                return np.array([
-                    [product_trace(comp, tdm(i, prop_level))
-                     for comp in dipole_integrals]
-                    for i in np.arange(len(self.excitation_energy))
-                ])
+            prop_level = "adc" + str(self.property_method.level - 1)
+            return np.array([
+                [product_trace(comp, tdm(i, prop_level))
+                    for comp in dipole_integrals]
+                for i in np.arange(len(self.excitation_energy))
+            ])
         else:
             return ("transition_dipole_moments_qed are only calculated,"
                     "if reference_state contains 'approx' attribute")
@@ -235,7 +227,7 @@ class ElectronicTransition:
 
             block_dict["qed_adc1_off_diag"] = final_block("adc1")
 
-            if self.method.name == "adc2" and not hasattr(self.reference_state, "first_order_coupling"):  # noqa: E501
+            if self.method.name == "adc2":
                 block_dict["qed_adc2_diag"] = final_block("qed_adc2_diag")
                 block_dict["qed_adc2_edge_couple"] = final_block("qed_adc2_edge_couple")  # noqa: E501
                 block_dict["qed_adc2_edge_phot_couple"] = final_block("qed_adc2_edge_phot_couple")  # noqa: E501

--- a/adcc/ElectronicTransition.py
+++ b/adcc/ElectronicTransition.py
@@ -223,16 +223,14 @@ class ElectronicTransition:
                                   for j in np.arange(n_states)]
                                  for i in np.arange(n_states)])
 
-            block_dict = {}
-
-            block_dict["qed_adc1_off_diag"] = final_block("adc1")
+            block_dict = {"qed_adc1_off_diag": final_block("adc1")}
 
             if self.method.name == "adc2":
-                block_dict["qed_adc2_diag"] = final_block("qed_adc2_diag")
-                block_dict["qed_adc2_edge_couple"] = final_block("qed_adc2_edge_couple")  # noqa: E501
-                block_dict["qed_adc2_edge_phot_couple"] = final_block("qed_adc2_edge_phot_couple")  # noqa: E501
-                block_dict["qed_adc2_ph_pphh"] = final_block("qed_adc2_ph_pphh")
-                block_dict["qed_adc2_pphh_ph"] = final_block("qed_adc2_pphh_ph")
+                keys = ("qed_adc2_diag", "qed_adc2_edge_couple",
+                        "qed_adc2_edge_phot_couple", "qed_adc2_ph_pphh",
+                        "qed_adc2_pphh_ph")
+                for key in keys:
+                    block_dict[key] = final_block(key)
             return block_dict
         else:
             return ("s2s_dipole_moments_qed are only calculated,"

--- a/adcc/ExcitedStates.py
+++ b/adcc/ExcitedStates.py
@@ -35,7 +35,6 @@ from .FormatIndex import (FormatIndexAdcc, FormatIndexBase,
 from .OneParticleOperator import product_trace
 from .ElectronicTransition import ElectronicTransition
 from .FormatDominantElements import FormatDominantElements
-from .AmplitudeVector import QED_AmplitudeVector
 
 
 class EnergyCorrection:
@@ -417,12 +416,6 @@ class ExcitedStates(ElectronicTransition):
 
         # Optimise the formatting by pre-inspecting all tensors
         for tensor in self.excitation_vector:
-            if isinstance(tensor, QED_AmplitudeVector):
-                # TODO: Implement tdm and s2s_tdm for QED, so properties can also
-                # be evaluated for QED_AmplitudeVector objects. For now only
-                # use AmplitudeVector describing the electric part, so the
-                # formatting does not have to be adapted.
-                tensor = tensor.elec
             vector_format.optimise_formatting(tensor)
 
         # Determine width of a line
@@ -431,13 +424,6 @@ class ExcitedStates(ElectronicTransition):
 
         ret = separator
         for i, vec in enumerate(self.excitation_vector):
-            if isinstance(vec, QED_AmplitudeVector):
-                # TODO: Implement tdm and s2s_tdm for QED, so properties can also
-                # be evaluated for QED_AmplitudeVector objects. For now only
-                # use AmplitudeVector describing the electric part, since
-                # most low-energy states are almost purely electric, so the
-                # formatting does not have to be adapted.
-                vec = vec.elec
             ene = self.excitation_energy[i]
             eev = ene * eV
             head = f"State {i:3d} , {ene:13.7g} au"

--- a/adcc/IsrMatrix.py
+++ b/adcc/IsrMatrix.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+## vi: tabstop=4 shiftwidth=4 softtabstop=4 expandtab
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2022 by the adcc authors
+##
+## This file is part of adcc.
+##
+## adcc is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published
+## by the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## adcc is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with adcc. If not, see <http://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+import libadcc
+
+from .AdcMatrix import AdcMatrixlike
+from .LazyMp import LazyMp
+from .adc_pp import bmatrix as ppbmatrix
+from .timings import Timer, timed_member_call
+from .AdcMethod import AdcMethod
+from .OneParticleOperator import OneParticleOperator
+from .AmplitudeVector import AmplitudeVector
+
+
+class IsrMatrix(AdcMatrixlike):
+    # Default perturbation-theory orders for the matrix blocks (== standard ADC-PP).
+    default_block_orders = {
+        #             ph_ph=0, ph_pphh=None, pphh_ph=None, pphh_pphh=None),
+        "adc0":  dict(ph_ph=0, ph_pphh=None, pphh_ph=None, pphh_pphh=None),  # noqa: E501
+        "adc1":  dict(ph_ph=1, ph_pphh=None, pphh_ph=None, pphh_pphh=None),  # noqa: E501
+        "adc2":  dict(ph_ph=2, ph_pphh=1,    pphh_ph=1,    pphh_pphh=0),     # noqa: E501
+        "adc2x": dict(ph_ph=2, ph_pphh=1,    pphh_ph=1,    pphh_pphh=1),     # noqa: E501
+        "adc3":  dict(ph_ph=3, ph_pphh=2,    pphh_ph=2,    pphh_pphh=1),     # noqa: E501
+    }
+
+    def __init__(self, method, hf_or_mp, operators, block_orders=None):
+        """
+        Initialise an ISR matrix of a given one-particle operator
+        for the provided ADC method.
+
+        Parameters
+        ----------
+        method : str or adcc.AdcMethod
+            Method to use.
+        hf_or_mp : adcc.ReferenceState or adcc.LazyMp
+            HF reference or MP ground state.
+        operators : adcc.OneParticleOperator or list of adcc.OneParticleOperator
+                    objects
+            One-particle matrix elements associated with a one-particle operator.
+        block_orders : optional
+            The order of perturbation theory to employ for each matrix block.
+            If not set, defaults according to the selected ADC method are chosen.
+        """
+        if isinstance(hf_or_mp, (libadcc.ReferenceState,
+                                 libadcc.HartreeFockSolution_i)):
+            hf_or_mp = LazyMp(hf_or_mp)
+        if not isinstance(hf_or_mp, LazyMp):
+            raise TypeError("hf_or_mp is not a valid object. It needs to be "
+                            "either a LazyMp, a ReferenceState or a "
+                            "HartreeFockSolution_i.")
+
+        if not isinstance(method, AdcMethod):
+            method = AdcMethod(method)
+
+        if not isinstance(operators, list):
+            self.operators = [operators]
+        else:
+            self.operators = operators.copy()
+        if not all(isinstance(op, OneParticleOperator) for op in self.operators):
+            raise TypeError("operators is not a valid object. It needs to be "
+                            "either an OneParticleOperator or a list of "
+                            "OneParticleOperator objects.")
+
+        self.timer = Timer()
+        self.method = method
+        self.ground_state = hf_or_mp
+        self.reference_state = hf_or_mp.reference_state
+        self.mospaces = hf_or_mp.reference_state.mospaces
+        self.is_core_valence_separated = method.is_core_valence_separated
+        self.ndim = 2
+        self.extra_terms = []
+
+        # Determine orders of PT in the blocks
+        if block_orders is None:
+            block_orders = self.default_block_orders[method.base_method.name]
+        else:
+            tmp_orders = self.default_block_orders[method.base_method.name].copy()
+            tmp_orders.update(block_orders)
+            block_orders = tmp_orders
+
+        # Sanity checks on block_orders
+        for block in block_orders.keys():
+            if block not in ("ph_ph", "ph_pphh", "pphh_ph", "pphh_pphh"):
+                raise ValueError(f"Invalid block order key: {block}")
+        if block_orders["ph_pphh"] != block_orders["pphh_ph"]:
+            raise ValueError("ph_pphh and pphh_ph should always have "
+                             "the same order")
+        if block_orders["ph_pphh"] is not None \
+           and block_orders["pphh_pphh"] is None:
+            raise ValueError("pphh_pphh cannot be None if ph_pphh isn't.")
+        self.block_orders = block_orders
+
+        # Build the blocks
+        with self.timer.record("build"):
+            variant = None
+            if self.is_core_valence_separated:
+                variant = "cvs"
+            blocks = [{
+                block: ppbmatrix.block(self.ground_state, operator,
+                                       block.split("_"), order=order,
+                                       variant=variant)
+                for block, order in self.block_orders.items() if order is not None
+            } for operator in self.operators]
+            # TODO Rename to self.block in 0.16.0
+            self.blocks_ph = [{
+                b: bl[b].apply for b in bl
+            } for bl in blocks]
+
+    @timed_member_call()
+    def matvec(self, v):
+        """
+        Compute the matrix-vector product of the ISR one-particle
+        operator and return the result.
+
+        If a list of OneParticleOperator objects was passed to the class
+        instantiation operator, a list of AmplitudeVector objects is returned.
+        """
+        ret = [
+            sum(block(v) for block in bl_ph.values())
+            for bl_ph in self.blocks_ph
+        ]
+        if len(ret) == 1:
+            return ret[0]
+        else:
+            return ret
+
+    def rmatvec(self, v):
+        # Hermitian operators
+        if all(op.is_symmetric for op in self.operators):
+            return self.matvec(v)
+        else:
+            diffv = [op.ov + op.vo.transpose((1, 0)) for op in self.operators]
+            # anti-Hermitian operators
+            if all(dv.dot(dv) < 1e-12 for dv in diffv):
+                return [
+                    AmplitudeVector(ph=-1.0 * mv.ph, pphh=-1.0 * mv.pphh)
+                    for mv in self.matvec(v)
+                ]
+            # operators without any symmetry
+            else:
+                return NotImplemented
+
+    def __matmul__(self, other):
+        """
+        If the matrix-vector product is to be calculated with multiple vectors,
+        a list of AmplitudeVector objects is returned.
+
+        Consequently, applying the ISR matrix with multiple operators to multiple
+        vectors results in an N_vectors x N_operators 2D list of AmplitudeVector
+        objects.
+        """
+        if isinstance(other, AmplitudeVector):
+            return self.matvec(other)
+        if isinstance(other, list):
+            if all(isinstance(elem, AmplitudeVector) for elem in other):
+                return [self.matvec(ov) for ov in other]
+        return NotImplemented

--- a/adcc/LazyMp.py
+++ b/adcc/LazyMp.py
@@ -181,7 +181,7 @@ class LazyMp:
         up to the specified order of perturbation theory
         """
         if level == 1:
-            if self.reference_state.qed:
+            if self.reference_state.is_qed:
                 return self.reference_state.density
             else:
                 return self.reference_state.density
@@ -278,7 +278,7 @@ class LazyMp:
         qed_mp2_correction = 0
         if level == 2 and not is_cvs:
             terms = [(1.0, hf.oovv, self.t2oo)]
-            if hf.qed:
+            if hf.is_qed:
                 total_dip = OneParticleOperator(self.mospaces, is_symmetric=True)
                 omega = ReferenceState.get_qed_omega(hf)
                 total_dip.ov = self.get_qed_total_dip.ov

--- a/adcc/LazyMp.py
+++ b/adcc/LazyMp.py
@@ -181,10 +181,7 @@ class LazyMp:
         up to the specified order of perturbation theory
         """
         if level == 1:
-            if self.reference_state.is_qed:
-                return self.reference_state.density
-            else:
-                return self.reference_state.density
+            return self.reference_state.density
         elif level == 2:
             return self.reference_state.density + self.mp2_diffdm
         else:

--- a/adcc/ReferenceState.py
+++ b/adcc/ReferenceState.py
@@ -38,8 +38,8 @@ __all__ = ["ReferenceState"]
 class ReferenceState(libadcc.ReferenceState):
     def __init__(self, hfdata, core_orbitals=None, frozen_core=None,
                  frozen_virtual=None, symmetry_check_on_import=False,
-                 import_all_below_n_orbs=10, qed=False, coupl=None,
-                 freq=None, qed_hf=True, qed_approx=False, qed_full_diag=False):
+                 import_all_below_n_orbs=10, is_qed=False, coupl=None,
+                 freq=None, qed_hf=True, qed_approx=False):
         """Construct a ReferenceState holding information about the employed
         SCF reference.
 
@@ -140,13 +140,12 @@ class ReferenceState(libadcc.ReferenceState):
         which would place the 2nd and 3rd alpha and the 1st and second
         beta orbital into the core space.
         """
-        self.qed = qed
+        self.is_qed = is_qed
         self.coupling = coupl
         self.frequency = np.real(freq)
         self.freq_with_loss = freq
         self.qed_hf = qed_hf
         self.approx = qed_approx
-        self.full_diagonalization = qed_full_diag
 
         if not isinstance(hfdata, libadcc.HartreeFockSolution_i):
             hfdata = import_scf_results(hfdata)
@@ -194,7 +193,7 @@ class ReferenceState(libadcc.ReferenceState):
         # factor needs to be adjusted depending on the input, but since the
         # hilbert package is currently the best in terms of performance, at
         # least to my knowledge, the factor should be included here.
-        if self.qed:
+        if self.is_qed:
             dips = self.operators.electric_dipole
             couplings = self.coupling
             freqs = self.frequency
@@ -209,7 +208,7 @@ class ReferenceState(libadcc.ReferenceState):
         """
         Return the cavity frequency
         """
-        if self.qed:
+        if self.is_qed:
             freqs = self.frequency
             return np.linalg.norm(freqs)
 
@@ -218,7 +217,7 @@ class ReferenceState(libadcc.ReferenceState):
         """
         Return the object, which is added to the ERIs in a PT QED calculation
         """
-        if self.qed:
+        if self.is_qed:
             from . import block as b
             from .functions import einsum
             total_dip = OneParticleOperator(self.mospaces, is_symmetric=True)
@@ -247,7 +246,7 @@ class ReferenceState(libadcc.ReferenceState):
             return ds[block]
 
     def eri(self, block):
-        if self.qed:
+        if self.is_qed:
             from . import block as b
             from .functions import einsum
             # Since there is no TwoParticleOperator object,

--- a/adcc/__init__.py
+++ b/adcc/__init__.py
@@ -69,7 +69,8 @@ __all__ = ["run_adc", "InputError", "AdcMatrix", "AdcBlockView",
 __version__ = "0.15.14"
 __license__ = "GPL v3"
 __url__ = "https://adc-connect.org"
-__authors__ = ["Michael F. Herbst", "Maximilian Scheurer", "Jonas Leitner"]
+__authors__ = ["Michael F. Herbst", "Maximilian Scheurer", "Jonas Leitner",
+               "Antonia Papapostolou"]
 __email__ = "developers@adc-connect.org"
 __contributors__ = []
 

--- a/adcc/adc_pp/bmatrix.py
+++ b/adcc/adc_pp/bmatrix.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+## vi: tabstop=4 shiftwidth=4 softtabstop=4 expandtab
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2022 by the adcc authors
+##
+## This file is part of adcc.
+##
+## adcc is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published
+## by the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## adcc is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with adcc. If not, see <http://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+from collections import namedtuple
+from adcc import block as b
+from adcc.functions import einsum
+from adcc.AmplitudeVector import AmplitudeVector
+
+
+__all__ = ["block"]
+
+
+#
+# Dispatch routine
+#
+
+"""
+`apply` is a function mapping an AmplitudeVector to the contribution of this
+block to the result of applying the ADC matrix.
+"""
+AdcBlock = namedtuple("AdcBlock", ["apply"])
+
+
+def block(ground_state, operator, spaces, order, variant=None):
+    """
+    Gets ground state, one-particle matrix elements associated
+    with a one-particle operator, spaces (ph, pphh and so on)
+    and the perturbation theory order for the block,
+    variant is "cvs" or sth like that.
+
+    The matrix-vector product was derived up to second order
+    using the original equations from
+    J. Schirmer and A. B. Trofimov, J. Chem. Phys. 120, 11449–11464 (2004).
+    """
+    if isinstance(variant, str):
+        variant = [variant]
+    elif variant is None:
+        variant = []
+
+    if ground_state.has_core_occupied_space and "cvs" not in variant:
+        raise ValueError("Cannot run a general (non-core-valence approximated) "
+                         "ADC method on top of a ground state with a "
+                         "core-valence separation.")
+    if not ground_state.has_core_occupied_space and "cvs" in variant:
+        raise ValueError("Cannot run a core-valence approximated ADC method on "
+                         "top of a ground state without a "
+                         "core-valence separation.")
+
+    fn = "_".join(["block"] + variant + spaces + [str(order)])
+
+    if fn not in globals():
+        raise ValueError("Could not dispatch: "
+                         f"spaces={spaces} order={order} variant=variant")
+    return globals()[fn](ground_state, operator)
+
+
+#
+# 0th order main
+#
+def block_ph_ph_0(ground_state, op):
+    def apply(ampl):
+        return AmplitudeVector(ph=(
+            + 1.0 * einsum('ic,ac->ia', ampl.ph, op.vv)
+            - 1.0 * einsum('ka,ki->ia', ampl.ph, op.oo)
+        ))
+    return AdcBlock(apply)
+
+
+def block_pphh_pphh_0(ground_state, op):
+    def apply(ampl):
+        return AmplitudeVector(pphh=0.5 * (
+            (
+                + 2.0 * einsum('ijcb,ac->ijab', ampl.pphh, op.vv)
+                - 2.0 * einsum('ijca,bc->ijab', ampl.pphh, op.vv)
+            ).antisymmetrise(2, 3)
+            + (
+                - 2.0 * einsum('kjab,ki->ijab', ampl.pphh, op.oo)
+                + 2.0 * einsum('kiab,kj->ijab', ampl.pphh, op.oo)
+            ).antisymmetrise(0, 1)
+        ))
+    return AdcBlock(apply)
+
+
+#
+# 0th order coupling
+#
+def block_ph_pphh_0(ground_state, op):
+    return AdcBlock(lambda ampl: 0, 0)
+
+
+def block_pphh_ph_0(ground_state, op):
+    return AdcBlock(lambda ampl: 0, 0)
+
+
+#
+# 1st order main
+#
+block_ph_ph_1 = block_ph_ph_0
+
+
+#
+# 1st order coupling
+#
+def block_ph_pphh_1(ground_state, op):
+    if op.is_symmetric:
+        op_vo = op.ov.transpose((1, 0))
+    else:
+        op_vo = op.vo.copy()
+    t2 = ground_state.t2(b.oovv)
+
+    def apply(ampl):
+        return AmplitudeVector(ph=0.5 * (
+            - 2.0 * einsum('ilad,ld->ia', ampl.pphh, op.ov)
+            + 2.0 * einsum('ilad,lndf,fn->ia', ampl.pphh, t2, op_vo)
+            + 2.0 * einsum('ilca,lc->ia', ampl.pphh, op.ov)
+            - 2.0 * einsum('ilca,lncf,fn->ia', ampl.pphh, t2, op_vo)
+            - 2.0 * einsum('klad,kled,ei->ia', ampl.pphh, t2, op_vo)
+            - 2.0 * einsum('ilcd,nlcd,an->ia', ampl.pphh, t2, op_vo)
+        ))
+    return AdcBlock(apply)
+
+
+def block_pphh_ph_1(ground_state, op):
+    if op.is_symmetric:
+        op_vo = op.ov.transpose((1, 0))
+    else:
+        op_vo = op.vo.copy()
+    t2 = ground_state.t2(b.oovv)
+
+    def apply(ampl):
+        return AmplitudeVector(pphh=0.5 * (
+            (
+                - 1.0 * einsum('ia,bj->ijab', ampl.ph, op_vo)
+                + 1.0 * einsum('ia,jnbf,nf->ijab', ampl.ph, t2, op.ov)
+                + 1.0 * einsum('ja,bi->ijab', ampl.ph, op_vo)
+                - 1.0 * einsum('ja,inbf,nf->ijab', ampl.ph, t2, op.ov)
+                + 1.0 * einsum('ib,aj->ijab', ampl.ph, op_vo)
+                - 1.0 * einsum('ib,jnaf,nf->ijab', ampl.ph, t2, op.ov)
+                - 1.0 * einsum('jb,ai->ijab', ampl.ph, op_vo)
+                + 1.0 * einsum('jb,inaf,nf->ijab', ampl.ph, t2, op.ov)
+            ).antisymmetrise(0, 1).antisymmetrise(2, 3)
+            + (
+                - 1.0 * einsum('ka,ijeb,ke->ijab', ampl.ph, t2, op.ov)
+                + 1.0 * einsum('kb,ijea,ke->ijab', ampl.ph, t2, op.ov)
+            ).antisymmetrise(2, 3)
+            + (
+                - 1.0 * einsum('ic,njab,nc->ijab', ampl.ph, t2, op.ov)
+                + 1.0 * einsum('jc,niab,nc->ijab', ampl.ph, t2, op.ov)
+            ).antisymmetrise(0, 1)
+        ))
+    return AdcBlock(apply)
+
+
+#
+# 2nd order main
+#
+def block_ph_ph_2(ground_state, op):
+    if op.is_symmetric:
+        op_vo = op.ov.transpose((1, 0))
+    else:
+        op_vo = op.vo.copy()
+    p0 = ground_state.mp2_diffdm
+    t2 = ground_state.t2(b.oovv)
+
+    def apply(ampl):
+        return AmplitudeVector(ph=(
+            # 0th order
+            + 1.0 * einsum('ic,ac->ia', ampl.ph, op.vv)
+            - 1.0 * einsum('ka,ki->ia', ampl.ph, op.oo)
+            # 2nd order
+            # (2,1)
+            - 1.0 * einsum('ic,jc,aj->ia', ampl.ph, p0.ov, op_vo)
+            - 1.0 * einsum('ka,kb,bi->ia', ampl.ph, p0.ov, op_vo)
+            - 1.0 * einsum('ic,ja,jc->ia', ampl.ph, p0.ov, op.ov)  # h.c.
+            - 1.0 * einsum('ka,ib,kb->ia', ampl.ph, p0.ov, op.ov)  # h.c.
+            # (2,2)
+            - 0.25 * einsum('ic,mnef,mnaf,ec->ia', ampl.ph, t2, t2, op.vv)
+            - 0.25 * einsum('ic,mnef,mncf,ae->ia', ampl.ph, t2, t2, op.vv)  # h.c.
+            # (2,3)
+            - 0.5 * einsum('ic,mnce,mnaf,ef->ia', ampl.ph, t2, t2, op.vv)
+            + 1.0 * einsum('ic,mncf,jnaf,jm->ia', ampl.ph, t2, t2, op.oo)
+            # (2,4)
+            + 0.25 * einsum('ka,mnef,inef,km->ia', ampl.ph, t2, t2, op.oo)
+            + 0.25 * einsum('ka,mnef,knef,mi->ia', ampl.ph, t2, t2, op.oo)  # h.c.
+            # (2,5)
+            - 1.0 * einsum('ka,knef,indf,ed->ia', ampl.ph, t2, t2, op.vv)
+            + 0.5 * einsum('ka,knef,imef,mn->ia', ampl.ph, t2, t2, op.oo)
+            # (2,6)
+            + 0.5 * einsum('kc,knef,inaf,ec->ia', ampl.ph, t2, t2, op.vv)
+            - 0.5 * einsum('kc,mncf,inaf,km->ia', ampl.ph, t2, t2, op.oo)
+            + 0.5 * einsum('kc,inef,kncf,ae->ia', ampl.ph, t2, t2, op.vv)  # h.c.
+            - 0.5 * einsum('kc,mnaf,kncf,mi->ia', ampl.ph, t2, t2, op.oo)  # h.c.
+            # (2,7)
+            - 1.0 * einsum('kc,kncf,imaf,mn->ia', ampl.ph, t2, t2, op.oo)
+            + 1.0 * einsum('kc,knce,inaf,ef->ia', ampl.ph, t2, t2, op.vv)
+        ))
+    return AdcBlock(apply)

--- a/adcc/adc_pp/transition_dm.py
+++ b/adcc/adc_pp/transition_dm.py
@@ -27,7 +27,7 @@ from adcc.LazyMp import LazyMp
 from adcc.AdcMethod import AdcMethod
 from adcc.functions import einsum
 from adcc.Intermediates import Intermediates
-from adcc.AmplitudeVector import AmplitudeVector, QED_AmplitudeVector
+from adcc.AmplitudeVector import AmplitudeVector
 from adcc.OneParticleOperator import OneParticleOperator
 
 from .util import check_doubles_amplitudes, check_singles_amplitudes
@@ -132,12 +132,8 @@ def transition_dm(method, ground_state, amplitude, intermediates=None):
         method = AdcMethod(method)
     if not isinstance(ground_state, LazyMp):
         raise TypeError("ground_state should be a LazyMp object.")
-    if not isinstance(amplitude, (AmplitudeVector, QED_AmplitudeVector)):
+    if not isinstance(amplitude, AmplitudeVector):
         raise TypeError("amplitude should be an AmplitudeVector object.")
-    if isinstance(amplitude, QED_AmplitudeVector):
-        # TODO: Implement the actual transition densities for the qed methods,
-        # but for now just return the electric contribution
-        amplitude = amplitude.elec
     if intermediates is None:
         intermediates = Intermediates(ground_state)
 

--- a/adcc/backends/psi4.py
+++ b/adcc/backends/psi4.py
@@ -169,20 +169,15 @@ class Psi4HFProvider(HartreeFockProvider):
     def get_restricted(self):
         if isinstance(self.wfn, (psi4.core.RHF, psi4.core.ROHF)):
             return True
-        elif isinstance(self.wfn, (psi4.core.Wavefunction)):
-            # This is the object returned by the hilbert package, which does
+        elif isinstance(self.wfn, psi4.core.UHF):
+            return False
+        else:
+            # The hilbert package returns a more basic object, which does
             # not provide a restricted indicator, so we determine it here
-            # and print the result
             orben_a = np.asarray(self.wfn.epsilon_a())
             orben_b = np.asarray(self.wfn.epsilon_b())
-            if all(orben_a == orben_b):
-                print("This is a restricted calculation")
-                return True
-            else:
-                print("This is an unrestricted calculation")
-                return False
-        else:
-            return False
+            # TODO Maybe give a small tolerance here
+            return all(orben_a == orben_b)
 
     def get_energy_scf(self):
         return self.wfn.energy()

--- a/adcc/functions.py
+++ b/adcc/functions.py
@@ -24,7 +24,7 @@ import libadcc
 
 import opt_einsum
 
-from .AmplitudeVector import AmplitudeVector, QED_AmplitudeVector
+from .AmplitudeVector import AmplitudeVector
 
 
 def dot(a, b):
@@ -122,26 +122,6 @@ def lincomb(coefficients, tensors, evaluate=False):
                            evaluate=evaluate)
             for block in tensors[0].blocks_ph
         })
-    elif isinstance(tensors[0], QED_AmplitudeVector):
-        gs1_part = 0
-        gs2_part = 0
-        elec_list = [ten.elec for ten in tensors]
-        phot_list = [ten.phot for ten in tensors]
-        phot2_list = [ten.phot2 for ten in tensors]
-        for coeff_ind, ten in enumerate(tensors):
-            gs1_part += coefficients[coeff_ind] * ten.gs1
-            gs2_part += coefficients[coeff_ind] * ten.gs2
-        elec_part = lincomb(coefficients, elec_list, evaluate=evaluate)
-        phot_part = lincomb(coefficients, phot_list, evaluate=evaluate)
-        phot2_part = lincomb(coefficients, phot2_list, evaluate=evaluate)
-        if "pphh" in elec_part.blocks_ph:
-            return QED_AmplitudeVector(elec_part.ph, elec_part.pphh,
-                                       gs1_part, phot_part.ph, phot_part.pphh,
-                                       gs2_part, phot2_part.ph, phot2_part.pphh)
-        else:
-            return QED_AmplitudeVector(elec_part.ph, None,
-                                       gs1_part, phot_part.ph, None,
-                                       gs2_part, phot2_part.ph, None)
     elif not isinstance(tensors[0], libadcc.Tensor):
         raise TypeError("Tensor type not supported")
 

--- a/adcc/guess/guesses_from_diagonal.py
+++ b/adcc/guess/guesses_from_diagonal.py
@@ -29,7 +29,6 @@ from itertools import groupby
 
 from ..AdcMatrix import AdcMatrixlike
 from .guess_zero import guess_zero
-from ..AmplitudeVector import AmplitudeVector
 
 
 def guesses_from_diagonal(matrix, n_guesses, block="ph", spin_change=0,
@@ -95,13 +94,13 @@ def guesses_from_diagonal(matrix, n_guesses, block="ph", spin_change=0,
     diag = matrix.diagonal()
 
     if qed_subblock == "phot":
-        diag = AmplitudeVector(**{"ph": diag.ph1, "pphh": diag.pphh1})
-        #if block == "pphh":
-        #    diag.pphh = diag.pphh1
+        diag.ph = diag.ph1
+        if block == "pphh":
+            diag.pphh = diag.pphh1
     elif qed_subblock == "phot2":
-        diag = AmplitudeVector(**{"ph": diag.ph2, "pphh": diag.pphh2})
-        #if block == "pphh":
-        #    diag.pphh = diag.pphh2
+        diag.ph = diag.ph2
+        if block == "pphh":
+            diag.pphh = diag.pphh2
 
     return guessfunction(matrix, n_guesses, diag, spin_change,
                          spin_block_symmetrisation, degeneracy_tolerance,

--- a/adcc/guess/guesses_from_diagonal.py
+++ b/adcc/guess/guesses_from_diagonal.py
@@ -91,17 +91,19 @@ def guesses_from_diagonal(matrix, n_guesses, block="ph", spin_change=0,
     else:
         raise ValueError(f"Don't know how to generate guesses for block {block}")
 
-    if qed_subblock is None:
-        diag = matrix.diagonal()
-    elif qed_subblock == "elec":
-        diag = matrix.diagonal().elec
-    elif qed_subblock == "phot":
-        diag = matrix.diagonal().phot
+    diag = matrix.diagonal().copy()
+
+    if qed_subblock == "phot":
+        diag.ph = diag.ph1
+        if block == "pphh":
+            diag.pphh = diag.pphh1
     elif qed_subblock == "phot2":
-        diag = matrix.diagonal().phot2
-    else:
-        raise KeyError("qed_subblock can only be None, elec, phot or phot2"
-                       "for guesses from diagonal")
+        diag.ph = diag.ph2
+        if block == "pphh":
+            diag.pphh = diag.pphh2
+    #else:
+    #    raise KeyError("qed_subblock can only be None, elec, phot or phot2"
+    #                   "for guesses from diagonal")
 
     return guessfunction(matrix, n_guesses, diag, spin_change,
                          spin_block_symmetrisation, degeneracy_tolerance,

--- a/adcc/guess/guesses_from_diagonal.py
+++ b/adcc/guess/guesses_from_diagonal.py
@@ -29,6 +29,7 @@ from itertools import groupby
 
 from ..AdcMatrix import AdcMatrixlike
 from .guess_zero import guess_zero
+from ..AmplitudeVector import AmplitudeVector
 
 
 def guesses_from_diagonal(matrix, n_guesses, block="ph", spin_change=0,
@@ -91,19 +92,16 @@ def guesses_from_diagonal(matrix, n_guesses, block="ph", spin_change=0,
     else:
         raise ValueError(f"Don't know how to generate guesses for block {block}")
 
-    diag = matrix.diagonal().copy()
+    diag = matrix.diagonal()
 
     if qed_subblock == "phot":
-        diag.ph = diag.ph1
-        if block == "pphh":
-            diag.pphh = diag.pphh1
+        diag = AmplitudeVector(**{"ph": diag.ph1, "pphh": diag.pphh1})
+        #if block == "pphh":
+        #    diag.pphh = diag.pphh1
     elif qed_subblock == "phot2":
-        diag.ph = diag.ph2
-        if block == "pphh":
-            diag.pphh = diag.pphh2
-    #else:
-    #    raise KeyError("qed_subblock can only be None, elec, phot or phot2"
-    #                   "for guesses from diagonal")
+        diag = AmplitudeVector(**{"ph": diag.ph2, "pphh": diag.pphh2})
+        #if block == "pphh":
+        #    diag.pphh = diag.pphh2
 
     return guessfunction(matrix, n_guesses, diag, spin_change,
                          spin_block_symmetrisation, degeneracy_tolerance,

--- a/adcc/solver/LanczosIterator.py
+++ b/adcc/solver/LanczosIterator.py
@@ -26,7 +26,7 @@ import scipy.linalg as la
 
 from adcc import evaluate, lincomb
 from adcc.timings import Timer
-from adcc.AmplitudeVector import AmplitudeVector, QED_AmplitudeVector
+from adcc.AmplitudeVector import AmplitudeVector
 
 from .orthogonaliser import GramSchmidtOrthogonaliser
 
@@ -64,7 +64,7 @@ class LanczosIterator:
         if not isinstance(guesses, list):
             guesses = [guesses]
         for guess in guesses:
-            if not isinstance(guess, (AmplitudeVector, QED_AmplitudeVector)):
+            if not isinstance(guess, AmplitudeVector):
                 raise TypeError("One of the guesses is not an AmplitudeVector")
         n_block = len(guesses)  # Lanczos block size
 

--- a/adcc/solver/davidson.py
+++ b/adcc/solver/davidson.py
@@ -28,7 +28,7 @@ import scipy.sparse.linalg as sla
 
 from adcc import evaluate, lincomb
 from adcc.AdcMatrix import AdcMatrixlike
-from adcc.AmplitudeVector import AmplitudeVector, QED_AmplitudeVector
+from adcc.AmplitudeVector import AmplitudeVector
 
 from .common import select_eigenpairs
 from .preconditioner import JacobiPreconditioner
@@ -358,7 +358,7 @@ def eigsh(matrix, guesses, n_ep=None, max_subspace=None,
     if not isinstance(matrix, AdcMatrixlike):
         raise TypeError("matrix is not of type AdcMatrixlike")
     for guess in guesses:
-        if not isinstance(guess, (AmplitudeVector, QED_AmplitudeVector)):
+        if not isinstance(guess, AmplitudeVector):
             raise TypeError("One of the guesses is not of type AmplitudeVector")
 
     if preconditioner is not None and isinstance(preconditioner, type):
@@ -375,10 +375,7 @@ def eigsh(matrix, guesses, n_ep=None, max_subspace=None,
     if not max_subspace:
         # TODO Arnoldi uses this:
         # max_subspace = max(2 * n_ep + 1, 20)
-        if matrix.reference_state.full_diagonalization:
-            max_subspace = len(guesses)
-        else:
-            max_subspace = max(6 * n_ep, 20, 5 * len(guesses))
+        max_subspace = max(6 * n_ep, 20, 5 * len(guesses))
 
     def convergence_test(state):
         state.residuals_converged = state.residual_norms < conv_tol

--- a/adcc/solver/preconditioner.py
+++ b/adcc/solver/preconditioner.py
@@ -23,7 +23,7 @@
 import numpy as np
 
 from adcc.AdcMatrix import AdcMatrixlike
-from adcc.AmplitudeVector import AmplitudeVector, QED_AmplitudeVector
+from adcc.AmplitudeVector import AmplitudeVector
 
 
 class PreconditionerIdentity:
@@ -64,12 +64,6 @@ class JacobiPreconditioner:
 
     def apply(self, invecs):
         if isinstance(invecs, AmplitudeVector):
-            if not isinstance(self.shifts, (float, np.number)):
-                raise TypeError("Can only apply JacobiPreconditioner "
-                                "to a single vector if shifts is "
-                                "only a single number.")
-            return invecs / (self.diagonal - self.shifts)
-        elif isinstance(invecs, QED_AmplitudeVector):
             if not isinstance(self.shifts, (float, np.number)):
                 raise TypeError("Can only apply JacobiPreconditioner "
                                 "to a single vector if shifts is "

--- a/adcc/test_IsrMatrix.py
+++ b/adcc/test_IsrMatrix.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+## vi: tabstop=4 shiftwidth=4 softtabstop=4 expandtab
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2022 by the adcc authors
+##
+## This file is part of adcc.
+##
+## adcc is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published
+## by the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## adcc is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with adcc. If not, see <http://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+import unittest
+import itertools
+import numpy as np
+
+from adcc.IsrMatrix import IsrMatrix
+from adcc.testdata.cache import cache
+from adcc.OneParticleOperator import product_trace
+from adcc.adc_pp.state2state_transition_dm import state2state_transition_dm
+from adcc.misc import expand_test_templates
+
+
+testcases = [("h2o_sto3g", "singlet"), ("cn_sto3g", "state")]
+methods = ["adc0", "adc1", "adc2"]
+operator_kinds = ["electric", "magnetic"]
+
+
+@expand_test_templates(list(itertools.product(testcases, methods, operator_kinds)))
+class TestIsrMatrix(unittest.TestCase):
+    def template_matrix_vector_product(self, case, method, op_kind):
+        (system, kind) = case
+        state = cache.adc_states[system][method][kind]
+        mp = state.ground_state
+        if op_kind == "electric":  # example of a symmetric operator
+            dips = state.reference_state.operators.electric_dipole
+        elif op_kind == "magnetic":  # example of an asymmetric operator
+            dips = state.reference_state.operators.magnetic_dipole
+        else:
+            raise NotImplementedError(
+                "Tests are only implemented for"
+                "electric and magnetic dipole operators."
+            )
+
+        # computing Y_m @ B @ Y_n yields the state-to-state
+        # transition dipole moments (n->m) (for n not equal to m)
+        # they can either be obtained using the matvec method of the IsrMatrix
+        # class or via the state-to-state transition density matrices
+        # (the second method serves as a reference here)
+
+        matrix = IsrMatrix(method, mp, dips)
+        for excitation1 in state.excitations:
+            resv = matrix @ excitation1.excitation_vector
+            for excitation2 in state.excitations:
+                s2s_tdm = [excitation2.excitation_vector @ v for v in resv]
+                tdm = state2state_transition_dm(
+                    state.property_method, mp,
+                    excitation1.excitation_vector,
+                    excitation2.excitation_vector,
+                    state.matrix.intermediates
+                )
+                s2s_tdm_ref = np.array([product_trace(tdm, dip) for dip in dips])
+                np.testing.assert_allclose(s2s_tdm, s2s_tdm_ref, atol=1e-12)
+
+
+class TestIsrMatrixInterface(unittest.TestCase):
+    def test_matvec(self):
+        system = "h2o_sto3g"
+        method = "adc2"
+        kind = "singlet"
+
+        state = cache.adc_states[system][method][kind]
+        mp = state.ground_state
+        dips = state.reference_state.operators.electric_dipole
+        magdips = state.reference_state.operators.magnetic_dipole
+        vecs = [exc.excitation_vector for exc in state.excitations[:2]]
+
+        matrix_ref = IsrMatrix(method, mp, dips)
+        refv1, refv2 = matrix_ref @ vecs
+
+        # multiple vectors
+        for i, dip in enumerate(dips):
+            matrix = IsrMatrix(method, mp, dip)
+            resv1, resv2 = matrix @ vecs
+            diffs = [refv1[i] - resv1, refv2[i] - resv2]
+            for j in range(2):
+                assert diffs[j].ph.dot(diffs[j].ph) < 1e-12
+                assert diffs[j].pphh.dot(diffs[j].pphh) < 1e-12
+
+        # compute Y_n @ B @ Y_n with matvec and rmatvec
+        # symmetric operators
+        for vec1 in vecs:
+            for vec2 in vecs:
+                resl = [vec1 @ mvprod for mvprod in matrix_ref.matvec(vec2)]
+                resr = [mvprod @ vec2 for mvprod in matrix_ref.rmatvec(vec1)]
+                np.testing.assert_allclose(
+                    np.array(resl), np.array(resr), atol=1e-12
+                )
+
+        # anti-symmetric operators
+        magmatrix = IsrMatrix(method, mp, magdips)
+        for vec1 in vecs:
+            for vec2 in vecs:
+                resl = [vec1 @ mvprod for mvprod in magmatrix.matvec(vec2)]
+                resr = [mvprod @ vec2 for mvprod in magmatrix.rmatvec(vec1)]
+                np.testing.assert_allclose(
+                    np.array(resl), np.array(resr), atol=1e-12
+                )

--- a/adcc/test_qed.py
+++ b/adcc/test_qed.py
@@ -55,7 +55,7 @@ class qed_test(unittest.TestCase):
         self.refstate.frequency = [0.0, 0.0, 0.5]
         self.refstate.freq_with_loss = self.refstate.frequency
         self.refstate.qed_hf = True
-        self.refstate.qed = True
+        self.refstate.is_qed = True
 
     def template_approx(self, case, method):
         self.set_refstate(case)

--- a/adcc/workflow.py
+++ b/adcc/workflow.py
@@ -51,7 +51,7 @@ def run_adc(data_or_matrix, n_states=None, kind="any", conv_tol=None,
             frozen_core=None, frozen_virtual=None, method=None,
             n_singlets=None, n_triplets=None, n_spin_flip=None,
             environment=None, coupl=None, freq=None, qed_hf=True,
-            qed_approx=False, qed_full_diag=False, **solverargs):
+            qed_approx=False, **solverargs):
     """Run an ADC calculation.
 
     Main entry point to run an ADC calculation. The reference to build the ADC
@@ -153,11 +153,6 @@ def run_adc(data_or_matrix, n_states=None, kind="any", conv_tol=None,
         Indicates whether the approximate solution for the qed method should
         be calculated. (After paper is published, put link here)
 
-    qed_full_diag : bool, optional
-        If the full solution to the qed method is required, the performance
-        of the standard qed guess is very poor. In that case, this guess
-        performs much better.
-
 
     Other parameters
     ----------------
@@ -205,14 +200,12 @@ def run_adc(data_or_matrix, n_states=None, kind="any", conv_tol=None,
     matrix = construct_adcmatrix(
         data_or_matrix, core_orbitals=core_orbitals, frozen_core=frozen_core,
         frozen_virtual=frozen_virtual, method=method, coupl=coupl,
-        freq=freq, qed_hf=qed_hf, qed_approx=qed_approx,
-        qed_full_diag=qed_full_diag)
+        freq=freq, qed_hf=qed_hf, qed_approx=qed_approx)
 
     n_states, kind = validate_state_parameters(
         matrix.reference_state, n_states=n_states, n_singlets=n_singlets,
         n_triplets=n_triplets, n_spin_flip=n_spin_flip, kind=kind, coupl=coupl,
-        freq=freq, qed_hf=qed_hf, qed_approx=qed_approx,
-        qed_full_diag=qed_full_diag)
+        freq=freq, qed_hf=qed_hf, qed_approx=qed_approx)
 
     # Determine spin change during excitation. If guesses is not None,
     # i.e. user-provided, we cannot guarantee for obtaining a particular
@@ -244,11 +237,10 @@ def run_adc(data_or_matrix, n_states=None, kind="any", conv_tol=None,
     exstates += env_energy_corrections
 
     # Build QED (approximated) matrix from "standard" ADC matrix
-    # and expectation values, if requested.
-
+    # and expectation values, if requested
     if matrix.reference_state.approx:
         qed_matrix = qed_matrix_from_diag_adc(exstates, matrix.reference_state)
-        if method == "adc2" and not hasattr(matrix.reference_state, "first_order_coupling"):  # noqa: E501
+        if method == "adc2":
             qed_eigvals, qed_eigvecs = qed_matrix.second_order_coupling()
         else:
             qed_eigvals, qed_eigvecs = qed_matrix.first_order_coupling()
@@ -269,8 +261,7 @@ def run_adc(data_or_matrix, n_states=None, kind="any", conv_tol=None,
 #
 def construct_adcmatrix(data_or_matrix, core_orbitals=None, frozen_core=None,
                         frozen_virtual=None, method=None, coupl=None,
-                        freq=None, qed_hf=True, qed_approx=False,
-                        qed_full_diag=False):
+                        freq=None, qed_hf=True, qed_approx=False):
     """
     Use the provided data or AdcMatrix object to check consistency of the
     other passed parameters and construct the AdcMatrix object representing
@@ -294,16 +285,16 @@ def construct_adcmatrix(data_or_matrix, core_orbitals=None, frozen_core=None,
                              "core_orbitals.")
         try:
             if coupl is not None:
-                qed = True
+                is_qed = True
             else:
-                qed = False
+                is_qed = False
             refstate = adcc_ReferenceState(data_or_matrix,
                                            core_orbitals=core_orbitals,
                                            frozen_core=frozen_core,
                                            frozen_virtual=frozen_virtual,
-                                           qed=qed, coupl=coupl, qed_hf=qed_hf,
-                                           freq=freq, qed_approx=qed_approx,
-                                           qed_full_diag=qed_full_diag)
+                                           is_qed=is_qed, coupl=coupl,
+                                           qed_hf=qed_hf, freq=freq,
+                                           qed_approx=qed_approx)
         except ValueError as e:
             raise InputError(str(e))  # In case of an issue with the spaces
         data_or_matrix = refstate
@@ -343,7 +334,7 @@ def construct_adcmatrix(data_or_matrix, core_orbitals=None, frozen_core=None,
 def validate_state_parameters(reference_state, n_states=None, n_singlets=None,
                               n_triplets=None, n_spin_flip=None, kind="any",
                               coupl=None, freq=None, qed_hf=True,
-                              qed_approx=False, qed_full_diag=False):
+                              qed_approx=False):
     """
     Check the passed state parameters for consistency with itself and with
     the passed reference and normalise them. In the end return the number of
@@ -423,9 +414,6 @@ def validate_state_parameters(reference_state, n_states=None, n_singlets=None,
     if not qed_hf:
         raise InputError("QED-ADC of zeroth and first level are not yet "
                          "properly tested and second order is not implemented")
-    if qed_full_diag:
-        raise Warning("Care to only request qed_full_diag=True, if you ask for "
-                      "the maximum number of states possible")
 
     return n_states, kind
 
@@ -477,12 +465,11 @@ def diagonalise_adcmatrix(matrix, n_states, kind, eigensolver="davidson",
     if guesses is None:
         if n_guesses is None:
             n_guesses = estimate_n_guesses(matrix, n_states, n_guesses_per_state)
-        if matrix.reference_state.qed and not matrix.reference_state.approx:
-            guesses = obtain_guesses_by_inspection_qed(matrix, n_guesses, kind,
-                                                       n_guesses_doubles)
+        if matrix.reference_state.is_qed and not matrix.reference_state.approx:
+            guess_function = obtain_guesses_by_inspection_qed
         else:
-            guesses = obtain_guesses_by_inspection(matrix, n_guesses, kind,
-                                                   n_guesses_doubles)
+            guess_function = obtain_guesses_by_inspection
+        guesses = guess_function(matrix, n_guesses, kind, n_guesses_doubles)
     else:
         if len(guesses) < n_states:
             raise InputError("Less guesses provided via guesses (== {}) "
@@ -583,7 +570,7 @@ def obtain_guesses_by_inspection(matrix, n_guesses, kind, n_guesses_doubles=None
 
 def obtain_guesses_by_inspection_qed(matrix, n_guesses, kind, n_guesses_doubles=None):  # noqa: E501
     """
-    Obtain guesses for QED_AmplitudeVectors, by pushing the subblocks
+    Obtain guesses for full qed method, by pushing the subblocks
     into obtain_guesses_by_inspection.
     Internal function called from run_adc.
     """
@@ -593,28 +580,21 @@ def obtain_guesses_by_inspection_qed(matrix, n_guesses, kind, n_guesses_doubles=
         matrix, n_guesses, kind, n_guesses_doubles, qed_subblock="phot")
     guesses_phot2 = obtain_guesses_by_inspection(
         matrix, n_guesses, kind, n_guesses_doubles, qed_subblock="phot2")
-    n_guess = len(guesses_elec)
-    #omega = matrix.reference_state.get_qed_omega()
-    #guesses_phot = guesses_elec.ph.copy() + omega
-    #guesses_phot2 = guesses_elec.ph.copy() + 2 * omega
-
 
     # Usually only few states are requested and most of them are close
     # to pure electronic states, so we initialize the guess vectors
     # as almost purely electric guesses.
-    if not matrix.reference_state.full_diagonalization:
-        for i in np.arange(n_guess):
-            # TODO: maybe make these values accessible by a keyword, since
-            # they can tune the performance. From my experience these work
-            # very well though
-            guesses_phot[i] *= 0.02
-            guesses_phot2[i] *= 0.001
-    if n_guess != len(guesses_phot):
+    for i in np.arange(n_guesses):
+        # TODO: maybe make these values accessible by a keyword, since
+        # they can tune the performance. From my experience these work
+        # very well though
+        guesses_phot[i] *= 0.02
+        guesses_phot2[i] *= 0.001
+    if n_guesses != len(guesses_phot):
         raise InputError("amount of guesses for electronic and photonic must be "
                          "equal, but are {} electronic and {} photonic "
                          "guesses".format(len(guesses_elec), len(guesses_phot)))
 
-    #final_guesses = []
     zero = set_lt_scalar(0.0)
 
     if hasattr(guesses_elec[0], "pphh"):
@@ -625,73 +605,26 @@ def obtain_guesses_by_inspection_qed(matrix, n_guesses, kind, n_guesses_doubles=
             "pphh1": guesses_phot[guess_index].pphh,
             "gs2": zero.copy(), "ph2": guesses_phot2[guess_index].ph,
             "pphh2": guesses_phot2[guess_index].pphh
-        }) for guess_index in np.arange(n_guess)]
+        }) for guess_index in np.arange(n_guesses)]
     else:
         final_guesses = [AmplitudeVector(**{
             "ph": guesses_elec[guess_index].ph,
             "gs1": zero.copy(), "ph1": guesses_phot[guess_index].ph,
             "gs2": zero.copy(), "ph2": guesses_phot2[guess_index].ph
-        }) for guess_index in np.arange(n_guess)]
-
-    #for vec in final_guesses:
-    #    vec.gs1.set_from_ndarray(np.array([0]))
-    #    vec.gs2.set_from_ndarray(np.array([0]))
-    """
-    if matrix.reference_state.full_diagonalization:
-        full_guess = []
-
-        for qed_vec in guesses_tmp:
-            tmp_elec_vec = qed_vec.elec.copy() * 10
-            tmp_phot_vec = qed_vec.phot.copy() * 10
-            tmp_phot2_vec = qed_vec.phot2.copy() * 10
-
-            tmp_zero_vec = qed_vec.elec.zeros_like()
-
-            if "pphh" in matrix.axis_blocks:
-                full_guess.append(QED_AmplitudeVector(
-                    tmp_elec_vec.ph, tmp_elec_vec.pphh,
-                    0, tmp_zero_vec.ph, tmp_zero_vec.pphh,
-                    0, tmp_zero_vec.ph, tmp_zero_vec.pphh))
-                full_guess.append(QED_AmplitudeVector(
-                    tmp_zero_vec.ph, tmp_zero_vec.pphh,
-                    0, tmp_phot_vec.ph, tmp_phot_vec.pphh,
-                    0, tmp_zero_vec.ph, tmp_zero_vec.pphh))
-                full_guess.append(QED_AmplitudeVector(
-                    tmp_zero_vec.ph, tmp_zero_vec.pphh,
-                    0, tmp_zero_vec.ph, tmp_zero_vec.pphh,
-                    0, tmp_phot2_vec.ph, tmp_phot2_vec.pphh))
-            else:
-                full_guess.append(QED_AmplitudeVector(
-                    tmp_elec_vec.ph, None,
-                    0, tmp_zero_vec.ph, None,
-                    0, tmp_zero_vec.ph, None))
-                full_guess.append(QED_AmplitudeVector(
-                    tmp_zero_vec.ph, None,
-                    0, tmp_phot_vec.ph, None,
-                    0, tmp_zero_vec.ph, None))
-                full_guess.append(QED_AmplitudeVector(
-                    tmp_zero_vec.ph, None,
-                    0, tmp_zero_vec.ph, None,
-                    0, tmp_phot2_vec.ph, None))
-
-        full_guess.append(guesses_tmp[0].zeros_like())
-        full_guess.append(guesses_tmp[0].zeros_like())
-
-        final_guesses = full_guess
-    else:
-        final_guesses = guesses_tmp
-    """
+        }) for guess_index in np.arange(n_guesses)]
 
     # TODO: maybe make these values accessible by a keyword, since
     # they can tune the performance. From my experience these work
-    # very well though, but depending on how strong a state couples
+    # quite well though, but depending on how strong a state couples
     # to the single photon dispersion mode and how many states one
-    # requests, adjusting these values can significantly increase the
+    # requests, adjusting these values can increase the
     # convergence rate
-    final_guesses[len(final_guesses) - 2].gs1.set_from_ndarray(np.array([5]))   # for stronger coupling e.g. 2
-    final_guesses[len(final_guesses) - 1].gs2.set_from_ndarray(np.array([20]))  # for stronger coupling e.g. 5
+    # for stronger coupling e.g. 2
+    final_guesses[n_guesses - 2].gs1.set_from_ndarray(np.array([5]))
+    # for stronger coupling e.g. 5
+    final_guesses[n_guesses - 1].gs2.set_from_ndarray(np.array([20]))
 
-    return [vec / (np.sqrt(vec @ vec)) for vec in final_guesses]
+    return [vec / np.sqrt(vec @ vec) for vec in final_guesses]
 
 
 def setup_solver_printing(solmethod_name, matrix, kind, default_print,

--- a/adcc/workflow.py
+++ b/adcc/workflow.py
@@ -411,9 +411,9 @@ def validate_state_parameters(reference_state, n_states=None, n_singlets=None,
             else:
                 raise Warning("polarizations of the cavity photon different from "
                               "z polarization have not been thoroughly tested yet")
-    if not qed_hf:
-        raise InputError("QED-ADC of zeroth and first level are not yet "
-                         "properly tested and second order is not implemented")
+    if not qed_hf and qed_approx:
+        raise InputError("Approximate QED ADC method is only available for "
+                         "QED-HF reference")
 
     return n_states, kind
 

--- a/libadcc/pyiface/export_Tensor.cc
+++ b/libadcc/pyiface/export_Tensor.cc
@@ -23,6 +23,9 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <sstream>
+#include <libtensor/expr/bispace/bispace.h>
+#include "../AdcMemory.hh"
+#include "../tests/wrap_libtensor.hh"
 
 namespace libadcc {
 
@@ -346,6 +349,17 @@ static py::object Tensor___repr__(const Tensor& self) {
   return Tensor___str__(self);
 }
 
+static ten_ptr set_lt_scalar(const py::float_ n) {
+  auto adcmem_ptr = std::shared_ptr<AdcMemory>(new AdcMemory());
+  libtensor::bispace<1> bis(1);
+  std::vector<AxisInfo> ax{{"x", 1}};
+  double vector[] = {n};
+  auto v_ptr = std::make_shared<libtensor::btensor<1>>(bis);
+  libtensor::btod_import_raw<1>(vector, bis.get_bis().get_dims()).perform(*v_ptr);
+  std::shared_ptr<Tensor> tensor_ptr = wrap_libtensor(adcmem_ptr, ax, v_ptr);
+  return tensor_ptr;
+}
+
 //
 // Operations with a scalar
 //
@@ -540,6 +554,9 @@ void export_Tensor(py::module& m) {
   m.def("trace", &Tensor_trace_2, "tensor"_a);
   m.def("linear_combination_strict", &linear_combination_strict, "coefficients"_a,
         "tensors"_a);
+  // This is necessary for smooth handling of ground state contributions
+  // in AmplitudeVectors
+  m.def("set_lt_scalar", &set_lt_scalar, "a"_a);
 }
 
 }  // namespace libadcc

--- a/setup.py
+++ b/setup.py
@@ -500,7 +500,8 @@ adccsetup(
         "spectroscopy",
     ],
     #
-    author="Michael F. Herbst, Maximilian Scheurer, Jonas Leitner",
+    author=("Michael F. Herbst, Maximilian Scheurer, Jonas Leitner, "
+            "Antonia Papapostolou"),
     author_email="developers@adc-connect.org",
     license="GPL v3",
     url="https://adc-connect.org",


### PR DESCRIPTION
QED_AmplitudeVector has been removed, along with the full_diagonalization and the first_order_coupling options.

Still left to do:

- [ ] Too many qed specific arguments in run_adc...maybe summarize them all to one option dictionary for qed methods
- [ ] Approximate QED-ADC method is checked for as ReferenceState attribute, even though it doesn't affect the ReferenceState